### PR TITLE
fix(LDStatusPro.user.js): prioritize summary stats over cloud cache for visit-day counters

### DIFF
--- a/LDStatusPro.user.js
+++ b/LDStatusPro.user.js
@@ -1,7 +1,7 @@
  // ==UserScript==
     // @name         LDStatus Pro
     // @namespace    http://tampermonkey.net/
-    // @version      3.5.5.8.1
+    // @version      3.5.5.8
     // @description  在 Linux.do 和 IDCFlare 页面显示信任级别进度，支持历史趋势、里程碑通知、阅读时间统计、排行榜系统、我的活动查看。两站点均支持排行榜和云同步功能
     // @author       JackLiii
     // @license      MIT


### PR DESCRIPTION
> 在此感谢 @caigg188 的开源🫡，帮助我很大的忙，因为我刚入站一直担心自己短时间内没到二级，然后被取消账号资格清出去😭，有了您的项目可以看到升级进度以后，我就不焦虑了！再次感谢您的项目

# 对应 issue

#35 

# 目的

修复“访问天数等指标长期不变化”的显示问题，如下图（这个是我加入 L 站的第 3 天，同时 L 站数据也可以看到我 visit 3 天了，因此判断为可能代码上有 bug）所示：
<img width="328" height="234" alt="image" src="https://github.com/user-attachments/assets/cde5826c-8478-40c3-b461-63c5b54db127" />

# bug 分析

现有逻辑中云端数据优先且命中后直接返回，可能覆盖实时统计值；当云端未及时刷新时，用户会看到“访问天数不增加”等情况（如上图所示）。

# 解决方案  

调整 fallback 数据源优先级，先读取了 LinuxDo summary.json 的实时统计，然后再回退云端同步数据。这样就避免了云端旧缓存数据被优先渲染，导致数据看起来没有变化。

# 测试结果

将修改后的版本代码重新加入油猴刷新 linux.do 以后，可以看到数据正常同步了
<img width="322" height="331" alt="image" src="https://github.com/user-attachments/assets/ea94e89f-036a-41cc-bc31-7a055285fe81" />
