### PR TITLE
fix: 遮挡事件导致的退出登陆等按钮响应失败

### DIFF
--- a/ld-store/src/components/common/CornerActionMenu.vue
+++ b/ld-store/src/components/common/CornerActionMenu.vue
@@ -295,6 +295,7 @@ watch(
   width: 190px;
   height: 190px;
   z-index: 120;
+  pointer-events: none;
   --corner-action-bg: var(--glass-bg-light);
   --corner-action-border: var(--glass-border-light);
   --corner-action-shadow: 0 8px 16px var(--glass-shadow), inset 0 1px 0 var(--glass-shine);
@@ -490,6 +491,7 @@ watch(
   border: 1px solid var(--corner-fab-border);
   overflow: hidden;
   transition: transform 0.25s ease, box-shadow 0.25s ease;
+  pointer-events: auto;
 }
 
 .backtop-button {
@@ -509,6 +511,7 @@ watch(
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   transition: transform 0.28s ease, opacity 0.24s ease, box-shadow 0.24s ease, color 0.24s ease;
+  pointer-events: auto;
 }
 
 .backtop-button:hover {


### PR DESCRIPTION
closes #60 

给圆圈装饰层添加 pointer-events: none;

由于本机开发服务器以及浏览器的同源策略导致无法登陆测试，目测是没有问题的，还望管理员灰度测试一下有没有问题，辛苦～