### PR TITLE
修复 README 中损坏的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,11 +453,11 @@ LDStatusPro/
 
 ## ⭐ Star History
 
-<a href="https://www.star-history.com/#caigg188/LDStatusPro&Date">
+<a href="https://star-history.dera.page/#caigg188/LDStatusPro&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=caigg188/LDStatusPro&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=caigg188/LDStatusPro&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=caigg188/LDStatusPro&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=caigg188/LDStatusPro&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=caigg188/LDStatusPro&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=caigg188/LDStatusPro&type=Date" />
  </picture>
 </a>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -438,11 +438,11 @@ Some Firefox users may experience OAuth login failures due to privacy settings (
 
 ## ⭐ Star History
 
-<a href="https://www.star-history.com/#caigg188/LDStatusPro&Date">
+<a href="https://star-history.dera.page/#caigg188/LDStatusPro&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=caigg188/LDStatusPro&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=caigg188/LDStatusPro&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=caigg188/LDStatusPro&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=caigg188/LDStatusPro&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=caigg188/LDStatusPro&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=caigg188/LDStatusPro&type=Date" />
  </picture>
 </a>
 

--- a/README_TW.md
+++ b/README_TW.md
@@ -438,11 +438,11 @@ LDStatusPro/
 
 ## ⭐ Star History
 
-<a href="https://www.star-history.com/#caigg188/LDStatusPro&Date">
+<a href="https://star-history.dera.page/#caigg188/LDStatusPro&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=caigg188/LDStatusPro&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=caigg188/LDStatusPro&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=caigg188/LDStatusPro&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=caigg188/LDStatusPro&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=caigg188/LDStatusPro&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=caigg188/LDStatusPro&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
当前 README 中的 Star History 图表因 GitHub 星标 API 限制已损坏，无法正常加载。本 PR 将 README.md、README_EN.md、README_TW.md 中的星标图表链接切换到新的数据源 star-history.dera.page，修复图表显示问题，让仓库的星标历史重新可见。